### PR TITLE
[FPGA] Fix Merge Sort Sample for Older Quartus

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/README.md
@@ -61,7 +61,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 
 This section describes how the merge sort design is structured and how it takes advantage of the spatial compute of the FPGA.
 
-The figure below shows the conceptual view of the merge sort design to the user. The user streams data into a SYCL pipe (`InPipe`) and, after some delay, the elements are streamed out of a SYCL pipe (`OutPipe`), in sorted order. The number of elements that the merge sort design is capable of sorting is a runtime parameter, but it must be a power of 2. However, this restriction can be worked around by padding the input stream with min/max elements, depending on the direction of the sort (smallest-to-largest vs largest-to-smallest). This technique is demonstrated in this design (see the `fpga_sort` function in *main.cpp*).
+The figure below shows the conceptual view of the merge sort design to the user. The user streams data into a SYCL pipe (`InPipe`) and, after some delay, the elements are streamed out of a SYCL pipe (`OutPipe`), in sorted order. The number of elements that the merge sort design is capable of sorting is a runtime parameter, but it must be a power of 2. However, this restriction can be worked around by padding the input stream with min/max elements, depending on the direction of the sort (smallest-to-largest vs largest-to-smallest). This technique is demonstrated in this design (see the `FPGASort` function in *main.cpp*).
 
 ![sort_api](assets/sort_api.png)
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/CMakeLists.txt
@@ -28,7 +28,8 @@ else()
     endif()
 endif()
 
-# Older quartus versions do not support as many kernels in SYCL HLS when compiling for hardware
+# Older Quartus versions do not support as many kernels in the SYCL HLS flow
+# when compiling for hardware
 if (IS_BSP MATCHES "0")
     execute_process(COMMAND quartus_sh --version
         OUTPUT_VARIABLE QUARTUS_VERSION
@@ -36,10 +37,14 @@ if (IS_BSP MATCHES "0")
     string(REGEX MATCH "[0-9][0-9]\.[0-9]\.[0-9]"
         QUARTUS_VERSION
         "${QUARTUS_VERSION}")
-    message(STATUS "Detected Quartus Prime Shell version ${QUARTUS_VERSION}")
-    if (QUARTUS_VERSION VERSION_LESS 22.2.0)
-        message(STATUS "Limiting hardware performance due to Quartus Prime version")
-        set(LIMIT_HW_MERGE_UNITS_FLAG "-DLIMIT_HW_MERGE_UNITS=1")
+    if ("${QUARTUS_VERSION}" STREQUAL "")
+        message(WARNING "Could not determine Quartus Prime Shell version.")
+    else()
+        message(STATUS "Detected Quartus Prime Shell version ${QUARTUS_VERSION}")
+        if (QUARTUS_VERSION VERSION_LESS 22.2.0)
+            message(STATUS "Limiting hardware performance due to Quartus Prime version.")
+            set(LIMIT_HW_MERGE_UNITS_FLAG "-DLIMIT_HW_MERGE_UNITS=1")
+        endif()
     endif()
 endif()
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/CMakeLists.txt
@@ -28,6 +28,21 @@ else()
     endif()
 endif()
 
+# Older quartus versions do not support as many kernels in SYCL HLS when compiling for hardware
+if (IS_BSP MATCHES "0")
+    execute_process(COMMAND quartus_sh --version
+        OUTPUT_VARIABLE QUARTUS_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    string(REGEX MATCH "[0-9][0-9]\.[0-9]\.[0-9]"
+        QUARTUS_VERSION
+        "${QUARTUS_VERSION}")
+    message(STATUS "Detected Quartus Prime Shell version ${QUARTUS_VERSION}")
+    if (QUARTUS_VERSION VERSION_LESS 22.2.0)
+        message(STATUS "Limiting hardware performance due to Quartus Prime version")
+        set(LIMIT_HW_MERGE_UNITS_FLAG "-DLIMIT_HW_MERGE_UNITS=1")
+    endif()
+endif()
+
 # This is a Windows-specific flag that enables error handling in host code
 if(WIN32)
     set(WIN_FLAG "/EHsc")
@@ -84,7 +99,7 @@ set(EMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} ${ENABLE_USM} $
 set(EMULATOR_LINK_FLAGS "-fsycl -fintelfpga ${ENABLE_USM} ${MERGE_UNITS_FLAG} ${SORT_WIDTH_FLAG} ${BSP_FLAG}")
 set(SIMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -Xssimulation -DFPGA_SIMULATOR ${ENABLE_USM} ${MERGE_UNITS_FLAG} ${SORT_WIDTH_FLAG} ${BSP_FLAG}")
 set(SIMULATOR_LINK_FLAGS "-fsycl -fintelfpga -Xssimulation -Xsghdl -Xstarget=${FPGA_DEVICE} ${ENABLE_USM} ${MERGE_UNITS_FLAG} ${SORT_WIDTH_FLAG} ${USER_HARDWARE_FLAGS} ${BSP_FLAG}")
-set(HARDWARE_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} ${ENABLE_USM} ${MERGE_UNITS_FLAG} ${SORT_WIDTH_FLAG} -DFPGA_HARDWARE ${BSP_FLAG}")
+set(HARDWARE_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} ${ENABLE_USM} ${LIMIT_HW_MERGE_UNITS_FLAG} ${MERGE_UNITS_FLAG} ${SORT_WIDTH_FLAG} -DFPGA_HARDWARE ${BSP_FLAG}")
 set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga -Xshardware ${PROFILE_FLAG} -Xsparallel=2 ${SEED_FLAG} -Xstarget=${FPGA_DEVICE} ${ENABLE_USM} ${MERGE_UNITS_FLAG} ${SORT_WIDTH_FLAG} ${USER_HARDWARE_FLAGS} ${BSP_FLAG}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/main.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/main.cpp
@@ -30,6 +30,16 @@ constexpr bool kUseUSMHostAllocation = true;
 constexpr bool kUseUSMHostAllocation = false;
 #endif
 
+// Limits the number of merge units used in hardware to support older
+// versions of quartus.
+#if defined(LIMIT_HW_MERGE_UNITS)
+#if FPGA_HARDWARE
+#ifndef MERGE_UNITS
+#define MERGE_UNITS 4
+#endif
+#endif
+#endif
+
 // The number of merge units, which must be a power of 2.
 // This can be set by defining the preprocessor macro 'MERGE_UNITS'
 // otherwise the default value below is used.


### PR DESCRIPTION
# Existing Sample Changes
## Description

The `merge_sort` reference design fails in qsys-generate because versions of quartus older than `22.2` only support up to 32 bit interrupts. In SYCL HLS, we generate one irq per kernel for the CSR interface, thus limiting the number of kernels for older versions of Quartus fixes this issue. The number of kernels generated with `MERGE_UNITS=P` is `5P-2`, thus decreasing it from `P=8` to `P=4` gives us `5P-2 = 22 < 32` as required.

This change introduces a flag `LIMIT_HW_MERGE_UNITS` that sets the default `MERGE_UNITS` to 4 when specified *for hardware only*. This flag is overridden by a user-specified `MERGE_UNITS` flag, and does not affect the `MERGE_UNITS` value in simulator or emulator mode.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested with `board=Stratix10` and `acdskit/21.2`
In simulator flow: https://spetc.intel.com/testsummary?testRunIds=9250665
In default flow: https://spetc.intel.com/testsummary?testRunIds=9250700

- [x] Command Line